### PR TITLE
Solve the "array_merge" part of the lab

### DIFF
--- a/.github/workflows/arraymerge_gtest.yml
+++ b/.github/workflows/arraymerge_gtest.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Check out the code
       uses: actions/checkout@v2
     - name: Compile test code
-      run: g++ -Wall -g -o array_merge_test array_merge.c array_merge_test.cpp -lgtest -pthread -std=c++0x
+      run: g++ -Wall -g -o array_merge_test ../mergesort/mergesort.c array_merge.c array_merge_test.cpp -lgtest -pthread -std=c++0x
       working-directory: array_merge
     - name: Run test
       run: ./array_merge_test

--- a/.github/workflows/arraymerge_test_valgrind.yml
+++ b/.github/workflows/arraymerge_test_valgrind.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Check out the code
       uses: actions/checkout@v2
     - name: Compile code
-      run: g++ -Wall -g -o array_merge_test array_merge.c array_merge_test.cpp -lgtest -pthread -std=c++0x
+      run: g++ -Wall -g -o array_merge_test ../mergesort/mergesort.c array_merge.c array_merge_test.cpp -lgtest -pthread -std=c++0x
       working-directory: array_merge
     - name: Run test
       run: valgrind -v --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./array_merge_test

--- a/array_merge/array_merge.c
+++ b/array_merge/array_merge.c
@@ -1,6 +1,44 @@
+#include <stdlib.h>
+
 #include "array_merge.h"
+#include "../mergesort/mergesort.h"
+
+bool not_contained(int all_values[], int size, int value) {
+    for (int i=0; i<size; ++i) {
+        if (all_values[i] == value) {
+            return false;
+        }
+    }
+    return true;
+}
 
 int* array_merge(int num_arrays, int* sizes, int** values) {
   // This is obviously broken. It has the right type, though, eh?
-  return sizes;
+  int total_size = 0;
+  for (int i=0; i<num_arrays; ++i) {
+    total_size += sizes[i];
+  }
+
+  int* all_values = (int*) calloc(total_size+1, sizeof(int));
+
+  int k=0;
+  for (int i=0; i<num_arrays; ++i) {
+    for (int j=0; j<sizes[i]; ++j) {
+        int val = values[i][j];
+        if (not_contained(all_values, k, val)) {
+            all_values[k] = val;
+            ++k;
+        }
+    }
+  }
+
+  mergesort(k, all_values);
+
+  int* result = (int*) calloc(k+1, sizeof(int));
+  result[0] = k;
+  for (int i=0; i<k; ++i) {
+    result[i+1] = all_values[i];
+  }
+
+  return result;
 }

--- a/array_merge/array_merge_test.cpp
+++ b/array_merge/array_merge_test.cpp
@@ -63,7 +63,7 @@ TEST(ArrayMerge, Handle_multiple_copies_of_longer_list_different_orders) {
   int a1[] = { 5, 8, 9, 3, 2, 0, 6, 378293, 2, 0 };
   int a2[] = { 8, -52857, 0, 2, 3, 0, 2, 3, 6, 9 };
   int* a[] = { a0, a1, a2, a0, a1, a2, a0, a1, a2 };
-  int expected[] = { 7, -52857, -22345, 0, 2, 3, 5, 6, 8, 9, 378293 };
+  int expected[] = { 10, -52857, -22345, 0, 2, 3, 5, 6, 8, 9, 378293 };
   int* result;
 
   result = array_merge(num_arrays, sizes, a);


### PR DESCRIPTION
This solves the "array_merge" part of the lab.

I also fix a broken test value that will cause that test to fail; that change definitely needs to be copied back to the primary repo.

I also added `#include` statements to bring in `mergesort.h`; these should also probably get copied over, along with notes in the README about what's happening there.